### PR TITLE
Add passable action option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For example, if you want to get a video's duration:
 
 ```javascript
 // get the injected wistia service
-let wistia = get(this, 'wistia');
+let wistia = Ember.get(this, 'wistia');
 
 let matcher = '123example';
 let duration;
@@ -96,6 +96,25 @@ wistia.getVideo(matcher).then((video) => {
 ```
 
 For a list of methods that can be called from a Wistia video object, visit the Wistia Player API [Documentation on Methods](https://wistia.com/doc/player-api#methods).
+
+Additionally, you can pass an action into the default component called `videoInitialize` that will be fired once the video has loaded.
+This method returns the `video` object as well as the `matcher` passed in, allowing you to directly fire methods on the video object.
+For example, we can define an action in our controller:
+
+```javascript
+// controller.js in your app
+actions: {
+  someAction(video, matcher) {
+    video.bind('play', () => { console.log('Action fired') });
+  }
+}
+```
+
+You can then pass that in as a closure action into the component:
+
+```handlebars
+{{wistia-video matcher="123example" videoInitialize=(action "someAction")}}
+```
 
 ## Styling
 There is no styling set up by default for this component.

--- a/addon/components/wistia-video.js
+++ b/addon/components/wistia-video.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/wistia-video';
 
 const {
   Component,
+  K,
   Logger: { warn },
   computed,
   get,
@@ -16,6 +17,7 @@ export default Component.extend({
   wistia: service(),
   classNames: ['video-wrapper'],
   classNameBindings: ['isPlaying'],
+  videoInitialize: K,
 
   isPlaying: computed('matcher', function() {
     const wistia = get(this, 'wistia');
@@ -35,5 +37,15 @@ export default Component.extend({
       warn('You have not passed in a Wistia matcher');
     }
     this._super(...arguments);
+  },
+
+  didRender() {
+    const videoInitialize = get(this, 'videoInitialize');
+    const wistia = get(this, 'wistia');
+    const matcher = get(this, 'matcher');
+
+    wistia.getVideo(matcher).then((video) => {
+      videoInitialize(video, matcher);
+    });
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-wistia",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",

--- a/tests/integration/components/wistia-video-test.js
+++ b/tests/integration/components/wistia-video-test.js
@@ -1,8 +1,28 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const {
+  K,
+  Service,
+  RSVP: { Promise }
+} = Ember;
 
 moduleForComponent('wistia-video', 'Integration | Component | wistia video', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    const stubbedWistia = Service.extend({
+      addVideo: K,
+      getCurrentlyPlaying: K,
+      getVideo: function() {
+        return new Promise((resolve) => {
+          resolve({});
+        });
+      }
+    });
+    this.register('service:wistia', stubbedWistia);
+    this.inject.service('wistia', { as: 'wistia' });
+  }
 });
 
 test('it has a css class prefixed with wistia_async', function(assert) {
@@ -12,4 +32,14 @@ test('it has a css class prefixed with wistia_async', function(assert) {
 
   const videoDiv = this.$().find('.wistia_embed:eq(0)');
   assert.ok(videoDiv.hasClass('wistia_async_scottIsAwesome'), 'async class is added');
+});
+
+test('`videoInitialize` method is fired once component renders', function(assert) {
+  assert.expect(1);
+
+  this.set('videoInitialize', () => {
+    assert.ok(true, 'initialize function is called');
+  });
+
+  this.render(hbs`{{wistia-video matcher="scottIsAwesome" videoInitialize=videoInitialize}}`);
 });


### PR DESCRIPTION
# Why

This PR adds the ability to pass a closure action to the wistia-component which will be called with the video object once the component has rendered.
This allows user call methods on the Wistia video objects directly without going through the API of the Wistia Service.
