### PR TITLE
stub wistia.api calls in testing mode

### DIFF
--- a/addon/components/wistia-video.js
+++ b/addon/components/wistia-video.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/wistia-video';
 
 const {
   Component,
+  Logger,
   K,
   Logger: { warn },
   computed,
@@ -46,6 +47,8 @@ export default Component.extend({
 
     wistia.getVideo(matcher).then((video) => {
       videoInitialize(video, matcher);
+    }).catch((error) => {
+      Logger.log(error.msg);
     });
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-wistia",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "doc": "doc",
@@ -36,6 +36,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.5.1",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/unit/services/wistia-test.js
+++ b/tests/unit/services/wistia-test.js
@@ -1,7 +1,9 @@
 import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
+import sinon from 'sinon';
+import wait from 'ember-test-helpers/wait';
 
-const { get } = Ember;
+const { Logger, get } = Ember;
 
 moduleFor('service:wistia', 'Unit | Service | wistia');
 
@@ -17,7 +19,7 @@ test('#recordEmail tracks email and records tracking', function(assert) {
 
   const userEmail = 'test@scottisthebest.com';
 
-  service.maybeRecordEmail(video, userEmail);
+  service._maybeRecordEmail(video, userEmail);
 });
 
 test('#setCurrentlyPlaying updates currentlyPlaying property', function(assert) {
@@ -34,4 +36,18 @@ test('#setCurrentlyPlaying updates currentlyPlaying property', function(assert) 
   service.setCurrentlyPlaying(video);
 
   assert.equal(get(service, 'currentlyPlaying'), 'abc123', 'video is set');
+});
+
+test('#getVideo stubs API for testing', function(assert) {
+  assert.expect(2);
+  const service = this.subject();
+
+  service.getVideo('abc123').catch((error) => {
+    assert.equal(error.msg, 'No video was found');
+  });
+
+  Logger.log = sinon.spy();
+  return wait().then(() => {
+    assert.ok(Logger.log.calledWith('This API is disabled in testing for: abc123'));
+  });
 });


### PR DESCRIPTION
This PR should fix the issue of test suites attempting to hit the Wistia API and failing.  In testing mode, the API call simply returns `true` for the video object.  Added test coverage to assert that the correct error is logged in console to give clarity into what is happening.