### PR TITLE
Fix deprecations

### DIFF
--- a/addon/components/wistia-video.js
+++ b/addon/components/wistia-video.js
@@ -4,7 +4,6 @@ import layout from '../templates/components/wistia-video';
 const {
   Component,
   Logger,
-  K,
   Logger: { warn },
   computed,
   get,
@@ -18,7 +17,7 @@ export default Component.extend({
   wistia: service(),
   classNames: ['video-wrapper'],
   classNameBindings: ['isPlaying'],
-  videoInitialize: K,
+  videoInitialize() {},
 
   isPlaying: computed('matcher', function() {
     const wistia = get(this, 'wistia');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-qunit": "^3.1.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",

--- a/tests/integration/components/wistia-video-test.js
+++ b/tests/integration/components/wistia-video-test.js
@@ -3,7 +3,6 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
 const {
-  K,
   Service,
   RSVP: { Promise }
 } = Ember;
@@ -12,8 +11,8 @@ moduleForComponent('wistia-video', 'Integration | Component | wistia video', {
   integration: true,
   beforeEach() {
     const stubbedWistia = Service.extend({
-      addVideo: K,
-      getCurrentlyPlaying: K,
+      addVideo() {},
+      getCurrentlyPlaying() {},
       getVideo: function() {
         return new Promise((resolve) => {
           resolve({});


### PR DESCRIPTION
Ran ember watson to remove Ember.k from code and tests (RIP Ember.k, You had a good run)
Updated Ember-cli-quit to 3.x to remove factory for deprications
All NPM tests now pass including canary.