### PR TITLE
re-render wistia div on update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
+  - sudo chmod 4755 /opt/google/chrome/chrome-sandbox
   - npm config set spin false
   - npm install -g npm@4
   - npm --version

--- a/addon/templates/components/wistia-video.hbs
+++ b/addon/templates/components/wistia-video.hbs
@@ -1,1 +1,3 @@
-<div class="wistia_embed wistia_async_{{matcher}}"></div>
+{{#unless hideVideo}}
+  <div class="wistia_embed wistia_async_{{matcher}}"></div>
+{{/unless}}

--- a/tests/dummy/app/controllers/switch-video.js
+++ b/tests/dummy/app/controllers/switch-video.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+const { Controller, get, set } = Ember;
+
+export default Controller.extend({
+  originalMatcher: 'ndf5tllia5',
+  newMatcher: '3a7rcvkcqd',
+
+  init() {
+    this._super(...arguments);
+    set(this, 'matcher', get(this, 'originalMatcher'));
+  },
+
+  actions: {
+    switchVideo() {
+      let originalMatcher = get(this, 'originalMatcher');
+      let newMatcher = get(this, 'newMatcher');
+      let updatedMatcher = get(this, 'matcher') == originalMatcher ? newMatcher : originalMatcher;
+      set(this, 'matcher', updatedMatcher);
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
+  this.route('switch-video');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/switch-video.js
+++ b/tests/dummy/app/routes/switch-video.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend();

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -5,3 +5,23 @@
   top: 0;
   width: 100%;
 }
+
+.non-full-screen .video-wrapper {
+  height: 300px;
+}
+
+.non-full-screen .wistia_embed {
+  position: relative;
+}
+
+.wistia-button {
+  text-decoration: none;
+  color: #fff;
+  background-color: #26a69a;
+  text-align: center;
+ 	letter-spacing: .5px;
+	width: 50%;
+  max-width: 300px;
+  font-size: 150%;
+  height: 50px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,1 @@
-{{wistia-video matcher="ndf5tllia5"}}
+{{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,1 @@
+{{wistia-video matcher="ndf5tllia5"}}

--- a/tests/dummy/app/templates/switch-video.hbs
+++ b/tests/dummy/app/templates/switch-video.hbs
@@ -1,0 +1,4 @@
+<div class="non-full-screen">
+  {{wistia-video matcher=matcher}}
+</div>
+<button class="wistia-button" type="button" {{action "switchVideo"}}>Switch video</button>

--- a/tests/integration/components/wistia-video-test.js
+++ b/tests/integration/components/wistia-video-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
 
 const {
   Service,
@@ -29,7 +30,7 @@ test('it has a css class prefixed with wistia_async', function(assert) {
 
   this.render(hbs`{{wistia-video matcher="scottIsAwesome"}}`);
 
-  const videoDiv = this.$().find('.wistia_embed:eq(0)');
+  let videoDiv = this.$().find('.wistia_embed:eq(0)');
   assert.ok(videoDiv.hasClass('wistia_async_scottIsAwesome'), 'async class is added');
 });
 
@@ -41,4 +42,19 @@ test('`videoInitialize` method is fired once component renders', function(assert
   });
 
   this.render(hbs`{{wistia-video matcher="scottIsAwesome" videoInitialize=videoInitialize}}`);
+});
+
+test('updating the `matcher` will rerender the wistia div', function(assert) {
+  assert.expect(4);
+  this.set('matcher', 'abc123');
+
+  this.render(hbs`{{wistia-video matcher=matcher}}`);
+  assert.ok(this.$('.wistia_embed:eq(0)').length, 'video hidden for remainder of run loop');
+  assert.ok(this.$('.wistia_embed:eq(0)').hasClass('wistia_async_abc123'), 'async class is added');
+
+  this.set('matcher', 'newvideo');
+  assert.notOk(this.$('.wistia_embed:eq(0)').length, 'video hidden for remainder of run loop');
+  return wait().then(() => {
+    assert.ok(this.$('.wistia_embed:eq(0)').hasClass('wistia_async_newvideo'), 'async class is added');
+  });
 });


### PR DESCRIPTION
# What's in this PR?
Closes #16 
  * Force wistia Div to rerender when the matcher changes by removing it from the DOM
